### PR TITLE
fix: 低版本小程序不支持replaceAll方法, 使用replace替换

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -40,7 +40,7 @@ export const createDataFieldsReactions = (target, options: IStoreBindings) => {
   if (namespace && typeof namespace !== "string") {
     throw new Error("[mobx-miniprogram] namespace only expect string");
   }
-  namespace = namespace.replaceAll(" ", "");
+  namespace = namespace.replace(new RegExp(" ","gm"),"");
 
   let namespaceData = Object.assign({}, target[namespace]);
 


### PR DESCRIPTION
namespace 使用了最新的小程序基础库版本才支持的string.replaceAll 方法, 导致低版本用户在createStoreBindings时候抛出错误 

![image](https://user-images.githubusercontent.com/18432488/132462736-9d92b8ed-2a0a-4574-9140-e395b4f5331d.png)

小程序官方查询结果

![image](https://user-images.githubusercontent.com/18432488/132462877-3891f4c6-daf1-4198-9b82-0bfd1e2fab6a.png)
